### PR TITLE
Fix DataLoader to handle absolute or relative path

### DIFF
--- a/OpenShiftLibrary/dataloader/dataloader.py
+++ b/OpenShiftLibrary/dataloader/dataloader.py
@@ -10,8 +10,9 @@ from OpenShiftLibrary.dataloader import UrlLoader
 
 class DataLoader(FileLoader, UrlLoader):
     def from_file(self, path: str) -> str:
-        cwd = os.getcwd()
-        with open(rf'{cwd}/{path}') as file:
+        if not os.path.isabs(path):
+            path = os.path.join(os.getcwd(), path)
+        with open(rf'{path}') as file:
             return file.read()
 
     def from_url(self, path: str) -> str:

--- a/robotframework/test-templates.robot
+++ b/robotframework/test-templates.robot
@@ -32,3 +32,8 @@ Test Template 6
   @{list} =  Oc Apply  Pod  test-data/template.yaml  namespace=default  template_data=${template_data}
   &{dictionary} =  Set Variable  ${list}[0]
   Oc Delete  kind=Pod  name=${dictionary.metadata.name}  namespace=default
+
+Test Template 7
+  @{list} =  Oc Apply  Pod  ${CURDIR}/../test-data/template.yaml  namespace=default  template_data={image: 'nginx', name: 'absolute-path'}
+  &{dictionary} =  Set Variable  ${list}[0]
+  Oc Delete  kind=Pod  name=${dictionary.metadata.name}  namespace=default


### PR DESCRIPTION
This change is mostly required when using OC keywords that receive absolute file path.
For example, trying to use Oc Apply with ${CURDIR} will fail without this fix.