### PR TITLE
fix _load_data method to handle invalid src argument

### DIFF
--- a/OpenShiftLibrary/keywords/generic.py
+++ b/OpenShiftLibrary/keywords/generic.py
@@ -288,12 +288,13 @@ class GenericKeywords(object):
                 return self.data_loader.from_file(src)
             except Exception as error:
                 self._handle_error(operation, f"Load data from file failed\n{error}")
-        if validators.url(src):
+        elif validators.url(src):
             try:
                 return self.data_loader.from_url(src)
             except Exception as error:
                 self._handle_error(operation, f"Load data from url failed\n{error}")
-        return src
+        else:
+            self._handle_error(operation, f"src argument was not a valid URL or file: {src}")
 
     def _load_template_data(self, operation: str, data: str, template_data: str) -> str:
         result: str


### PR DESCRIPTION
The current implementation of `_load_data` will fail if the `src` argument is not a valid file path nor URL and simply return the `src` string as it is.

This then causes the `_apply_or_create` method to fail at lines 273-275
```
result = [self._operate(kind, operation, api_version=api_version, body=item,
                                namespace=namespace or item.get('metadata', {}).get('namespace'),
                                **kwargs) for item in items]
```

With the following error:
```
ResourceOperationFailed: Apply failed
Reason: 'str' object has no attribute 'get'
```

The error message does not communicate what the problem was, so let's raise a more clear message in `_load_data` directly.