### PR TITLE
Fix SyntaxWarning: "is not" with a literal

### DIFF
--- a/OpenShiftLibrary/keywords/generic.py
+++ b/OpenShiftLibrary/keywords/generic.py
@@ -376,7 +376,7 @@ class GenericKeywords(object):
             item = item.get(field[0:-3], None) or item.get(field[0: -2], None)
             if item:
                 str_idx = field[-2:-1]
-                if str_idx is not '*' and str_idx is not '[':
+                if str_idx != '*' and str_idx != '[':
                     idx = int(str_idx) if str_idx.isdecimal() else None
                     item = item[idx] if idx is not None and idx < len(item) else None
         else:


### PR DESCRIPTION
This warning was introduced when we moved to Python 3.8: 
https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/

Changing "is not" to "!=" for String comparison is now required.